### PR TITLE
Update readme

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           path: /usr/share/miniconda/conda-bld/linux-64/${{ env.PACKAGE_NAME }}-*.tar.bz2
 
   build_and_test_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       matrix:
@@ -61,15 +61,25 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-activate-base: true
-          conda-build-version: "*"
-          activate-environment: true
-          python-version: ${{ matrix.python }}
 
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+          activate-environment: build
+          channels: conda-forge
+          python-version: ${{ matrix.python }}
+  
+      - name: Install conda build
+        run: |
+          conda activate
+          conda install -y conda-build
+          conda list -n base
+  
       - name: Build conda package
-        run: conda build --python ${{ matrix.python }} -c conda-forge --override-channels conda-recipe
+        run: |
+          conda activate
+          conda build --python ${{ matrix.python }} -c conda-forge --override-channels conda-recipe
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Provide the `build_ext` step with the path to the root VTune install directory.
 For instance, on Linux:
 
     export ITT_INCLUDE_DIR=$VTUNE_PROFILER_DIR/include
-    export ITT_LIBRARY_DIR=$VTUNE_PROFILE_DIR/lib64
+    export ITT_LIBRARY_DIR=$VTUNE_PROFILER_DIR/lib64
     python setup.py install
 
 The build assumes:

--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ Call `itt_pt_region_end()` on same thread to end current pt region instance.
 * [Intel Distribution for Python](https://software.intel.com/en-us/intel-distribution-for-python)
 * [ITT Task API Reference](https://software.intel.com/en-us/node/544206)
 
+## Related projects
+
+Intel(R) Instrumentation and Tracing API [project](https://github.com/intel/ittapi) now provides Python bindings
+in [pyitt](https://pypi.org/project/pyitt/) package available on PyPI. It provides `pyitt.compatibility_layers.itt_python`
+submodule which fully implements the public API of itt-python.
+
+Users of `itt` are advised to transition to using `pyitt`.
 
 ## Thanks
 


### PR DESCRIPTION
This PR fixes typo in README in the environment variable name reported in gh-15.

This PR adds section to README referring users to `pyitt` and advising them to transition to using it.